### PR TITLE
adding refresh-token-endpoint

### DIFF
--- a/lib/ea_restaurant_data_loader_web/controllers/oauth2_controller.ex
+++ b/lib/ea_restaurant_data_loader_web/controllers/oauth2_controller.ex
@@ -11,7 +11,6 @@ defmodule EaRestaurantDataLoaderWeb.Controllers.Oauth2Controller do
         [basic_auth | _] = conn |> get_req_header("authorization")
 
         Oauth2Util.extract_client_credentials_from_basic_auth(basic_auth)
-
       rescue
         _ in MatchError -> raise BadRequest
       end
@@ -20,5 +19,20 @@ defmodule EaRestaurantDataLoaderWeb.Controllers.Oauth2Controller do
       Oauth2Service.login_client(client_id, client_secret) |> ApplicationUtil.parse_to_json()
 
     send_resp(conn, :ok, login_json_response)
+  end
+
+  def refresh_token(conn, _params) do
+    %{
+      "access_token" => access_token,
+      "refresh_token" => refresh_token,
+      "client_id" => client_id,
+      "client_secret" => client_secret
+    } = conn.body_params
+
+    {_, refresh_token_json_response} =
+      Oauth2Service.refresh_token(refresh_token, access_token, client_id, client_secret)
+      |> ApplicationUtil.parse_to_json()
+
+    send_resp(conn, :ok, refresh_token_json_response)
   end
 end

--- a/lib/ea_restaurant_data_loader_web/error_handlers/custom_error_handler.ex
+++ b/lib/ea_restaurant_data_loader_web/error_handlers/custom_error_handler.ex
@@ -1,6 +1,8 @@
 defmodule EaRestaurantDataLoaderWeb.ErrorHandlers.CustomErrorHandler do
   alias EaRestaurantDataLoader.Lib.ErrorHandlers.InvalidCredentialsError
   alias EaRestaurantDataLoader.Lib.ErrorHandlers.BadRequest
+  alias EaRestaurantDataLoader.Lib.ErrorHandlers.TokenExpiredError
+  alias EaRestaurantDataLoader.Lib.ErrorHandlers.InvalidTokenError
 
   def handle(reason) do
 
@@ -9,6 +11,12 @@ defmodule EaRestaurantDataLoaderWeb.ErrorHandlers.CustomErrorHandler do
         {:unauthorized, reason.message}
       %BadRequest{} ->
         {:bad_request, reason.message}
+
+      %TokenExpiredError{} ->
+        {:unauthorized, reason.message}
+
+      %InvalidTokenError{} ->
+        {:unauthorized, reason.message}
 
         _ ->
         {:internal_server_error, "Internal Server Error"}

--- a/lib/ea_restaurant_data_loader_web/router.ex
+++ b/lib/ea_restaurant_data_loader_web/router.ex
@@ -11,6 +11,7 @@ defmodule EaRestaurantDataLoaderWeb.Router do
     pipe_through([:api])
 
     post("/login", Oauth2Controller, :login)
+    post("/refresh_token", Oauth2Controller, :refresh_token)
   end
 
   @impl Plug.ErrorHandler

--- a/lib/error_handlers/token_expired_error.ex
+++ b/lib/error_handlers/token_expired_error.ex
@@ -1,0 +1,3 @@
+defmodule EaRestaurantDataLoader.Lib.ErrorHandlers.TokenExpiredError do
+  defexception message: "Token expired"
+end

--- a/test/lib/services/oauth2_service_test.exs
+++ b/test/lib/services/oauth2_service_test.exs
@@ -9,6 +9,7 @@ defmodule EaRestaurantDataLoader.Test.Lib.Services.Oauth2ServiceTest do
   alias EaRestaurantDataLoader.Test.Fixtures.AppRefreshTokenFixture
   alias EaRestaurantDataLoader.Lib.Constants.Oauth2
   alias EaRestaurantDataLoader.Lib.ErrorHandlers.InvalidCredentialsError
+  alias EaRestaurantDataLoader.Lib.ErrorHandlers.TokenExpiredError
 
   describe "oauth2 service test" do
     test " client credential login" do
@@ -190,8 +191,8 @@ defmodule EaRestaurantDataLoader.Test.Lib.Services.Oauth2ServiceTest do
         )
 
       assert_raise(
-        MatchError,
-        ~r/no match of right hand side value: {:error, "Invalid token"}/,
+        TokenExpiredError,
+        ~r/Token expired/,
         fn ->
           Oauth2Service.refresh_token(
             expired_refresh_token,
@@ -213,7 +214,7 @@ defmodule EaRestaurantDataLoader.Test.Lib.Services.Oauth2ServiceTest do
           "postman001",
           user
         )
-    
+
       assert_raise(
           InvalidCredentialsError,
           ~r/Invalid Credentials/,


### PR DESCRIPTION
* Adding refresh token endpoint and controller
* Adding tests for refresh token scenarios:
   * refresh unexpired access token should return same access token
   * refresh expired access token should return a new access token when refresh token has not expired
   * refresh expired access token when refresh token expired should return an Token expired error.
  